### PR TITLE
Fix GGMLLayer reconstruction for GGUF quantized weights

### DIFF
--- a/any_device_parallel.py
+++ b/any_device_parallel.py
@@ -503,6 +503,41 @@ def clone_module_simple(module, target_device):
         except Exception as e:
             print(f"[ParallelAnything] Warning: Failed to reconstruct norm layer {module_class}: {e}")
     
+
+    is_ggml_layer = False
+    try:
+        from gguf.ops import GGMLLayer as GGMLLayer1
+        if isinstance(module, GGMLLayer1):
+            is_ggml_layer = True
+    except ImportError:
+        pass
+    if not is_ggml_layer:
+        try:
+            from gguf.pig import GGMLLayer as GGMLLayer2
+            if isinstance(module, GGMLLayer2):
+                is_ggml_layer = True
+        except ImportError:
+            pass
+
+    if is_ggml_layer:
+        try:
+            new_mod = module_class.__new__(module_class)
+            nn.Module.__init__(new_mod)
+            for name, value in module.__dict__.items():
+                if name in ('weight', 'bias'):
+                    continue
+                try:
+                    setattr(new_mod, name, copy.deepcopy(value))
+                except Exception:
+                    pass
+            if hasattr(module, 'weight') and module.weight is not None:
+                new_mod.weight = module.weight.to(target_device)
+            if hasattr(module, 'bias') and module.bias is not None:
+                new_mod.bias = module.bias.to(target_device)
+            return new_mod
+        except Exception as e:
+            print(f"[ParallelAnything] Warning: Failed to reconstruct GGML layer {module_class}: {e}")
+
     try:
         new_mod = module_class.__new__(module_class)
         nn.Module.__init__(new_mod)

--- a/any_device_parallel.py
+++ b/any_device_parallel.py
@@ -520,10 +520,11 @@ def clone_module_simple(module, target_device):
             pass
     if not is_ggml_layer:
         try:
-            from ComfyUI-GGUF.ops import GGMLLayer as GGMLLayer3
-            if isinstance(module, GGMLLayer3):
+            import importlib
+            gguf_mod = importlib.import_module('ComfyUI-GGUF.ops')
+            if isinstance(module, gguf_mod.GGMLLayer):
                 is_ggml_layer = True
-        except ImportError:
+        except (ImportError, ModuleNotFoundError):
             pass
 
     if is_ggml_layer:

--- a/any_device_parallel.py
+++ b/any_device_parallel.py
@@ -518,6 +518,13 @@ def clone_module_simple(module, target_device):
                 is_ggml_layer = True
         except ImportError:
             pass
+    if not is_ggml_layer:
+        try:
+            from ComfyUI-GGUF.ops import GGMLLayer as GGMLLayer3
+            if isinstance(module, GGMLLayer3):
+                is_ggml_layer = True
+        except ImportError:
+            pass
 
     if is_ggml_layer:
         try:


### PR DESCRIPTION
GGMLLayer (from gguf.ops or gguf.pig) stores quantized weights as plain tensor attributes rather than nn.Parameter. When clone_module_simple() tries to reconstruct it via the generic handler, it wraps the quantized weight in nn.Parameter(), which fails with 'Only Tensors of floating point and complex dtype can require gradients'.

This special case handles GGMLLayer by:
- Creating new instance via __new__ + nn.Module.__init__
- Deep-copying non-weight/bias attributes
- Moving weight/bias tensors to target device via .to() instead of wrapping

This stops the warning flood: 'Warning: Failed to reconstruct... Only Tensors of floating point and complex dtype can require gradients'